### PR TITLE
(feature) Webpack named entries takes foldername

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ module.exports = {
 };
 ```
 
+In case your filenames have name like `index.js`, pass the second parameter as `true`. This will take the filename name from your folder names.
+
+```
+var glob_entries = require('webpack-glob-entries')
+
+module.exports = {
+    entry: glob_entries('src/entries/**/*.js',true),
+    output: {
+        filename: '[name].js'
+    }
+};
+```
+
 ## Tests
 
   npm test
@@ -31,3 +44,4 @@ Add unit tests for any new or changed functionality. Lint and test your code.
 ## Release History
 
 * 1.0.0 Initial release
+* 1.0.2 Folder name is taken as input

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 var glob = require('glob'),
     path = require('path');
 
-module.exports = function (globPath) {
+module.exports = function (globPath, folderAsName) {
     var files = glob.sync(globPath);
     var entries = {};
 
     for (var i = 0; i < files.length; i++) {
-        var entry = files[i];
-        entries[path.basename(entry, path.extname(entry))] = entry;
+        var entry = folderAsName ? path.join(files[i]) : files[i];
+        var name = folderAsName ? path.dirname(entry).split(path.sep).pop() : path.basename(entry, path.extname(entry));
+        entries[name] = entry;
     }
-
     return entries;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 var should = require('chai').should(),
     assert = require('chai').assert,
+    expect = require('chai').expect,
     proxyquire = require('proxyquire'),
     glob_stub = {},
     webpack_glob_entries = proxyquire(
@@ -9,10 +10,10 @@ var should = require('chai').should(),
         }
     );
 
-describe('webpack_glob_entires', function() {
-    it('returns a entries hash from glob', function() {
+describe('webpack_glob_entires', function () {
+    it('returns a entries hash from glob', function () {
         var globFixture = '/**/*.js';
-        glob_stub.sync = function(glob) {
+        glob_stub.sync = function (glob) {
             glob.should.equal(globFixture);
 
             return ['/foo/foo.js', '/bar/bar.js'];
@@ -20,4 +21,17 @@ describe('webpack_glob_entires', function() {
 
         assert.deepEqual(webpack_glob_entries(globFixture), { foo: '/foo/foo.js', bar: '/bar/bar.js' });
     });
+
+    it('returns a foldername as entries hash from glob', function () {
+        var globFixture = '/**/*.js';
+        glob_stub.sync = function (glob) {
+            glob.should.equal(globFixture);
+
+            return ['/foo/index.js', '/bar/index.js'];
+        };
+
+        expect(webpack_glob_entries(globFixture, true)).have.keys(['foo', 'bar']);
+    });
+
+
 });


### PR DESCRIPTION
When glob file names have similar names like index.js. webpack-glob-entries creates only one output file.

Input like this ['/foo/index.js', '/bar/index.js'] would create output like {"index":"/bar/index.js"}. I have fixed it by taking one more parameter to take the folder name as key.

Now this function will create {"foo":"/foo/index.js","bar":"/bar/index.js"}